### PR TITLE
Create GitHub Actions job

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -25,3 +25,9 @@ jobs:
 
       - name: Generate Doxygen documentation
         uses: mattnotmitt/doxygen-action@v1.3.1
+        
+      - name: Deploy to GH Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./html

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,27 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Generate Doxygen documentation
+        uses: mattnotmitt/doxygen-action@v1.3.1

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,8 +1,5 @@
-# This is a basic workflow to help you get started with Actions
+name: Doxygen
 
-name: CI
-
-# Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
@@ -11,22 +8,17 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
       - name: Generate Doxygen documentation
         uses: mattnotmitt/doxygen-action@v1.3.1
         
-      - name: Deploy to GH Pages
+      - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Geen idee of dit gewenst is of onder een RFC valt; maar hiermee kan bij iedere commit een publieke instantie van de Doxygen documentatie op GitHub Pages gebouwd worden. Zie ook: https://spic-b.github.io/spic-prj-api/annotated.html

Moet wel nog even GH Pages aangezet worden op deze repo via Settings -> Pages en dan na de merge van deze PR de `gh-pages` branch (zou als het goed is aangemaakt moeten worden door de pages action; anders kan je hiervoor een orphan branch aanmaken).