### PR TITLE
Add @brief to Input.hpp

### DIFF
--- a/Input.hpp
+++ b/Input.hpp
@@ -6,6 +6,9 @@
 
 namespace spic {
 
+    /**
+     * @brief Some convenient input functions.
+     */
     namespace Input {
 
         /**


### PR DESCRIPTION
Wanneer je doxygen draait krijg je geen pagina te zien voor `Input`. Dit komt omdat er geen `@brief` comment boven de namespace staat. Deze PR lost dit op, waardoor je deze wel te zien krijg bij de HTML-output.