### PR TITLE
RFC: Remove Render() call from Sprite

### DIFF
--- a/Sprite.hpp
+++ b/Sprite.hpp
@@ -11,12 +11,6 @@ namespace spic {
      * @brief A component representing a sprite (small image)
      */
     class Sprite : public Component {
-        public:
-            /**
-             * @brief Call this method to render the sprite.
-             */
-            void Render();
-
         private:
             std::string sprite;
             Color color;


### PR DESCRIPTION
Besproken met Bob vd Putten en hij zou het hier ook nog over hebben.

Deze call lijkt heel erg op een foutje in de API specificatie, aangezien dit een System en een Component zou combineren. De signature van deze methode is ook niet logisch aangezien deze helemaal geen context heeft en void returned.