### PR TITLE
Replace type of Scene.contents

### DIFF
--- a/Scene.hpp
+++ b/Scene.hpp
@@ -18,7 +18,7 @@ namespace spic {
             /**
              * @brief This property contains all the Game Object that are contained in this scene.
              */
-            GameObject[] contents;
+            std::vector<std::shared_ptr<GameObject>> contents;
     };
 
 }


### PR DESCRIPTION
Before `GameObejct[]`. After `std::vector<std::shared_ptr<GameObject>>`.