### PR TITLE
Drop RenderScene from Scene

### DIFF
--- a/Scene.hpp
+++ b/Scene.hpp
@@ -11,12 +11,6 @@ namespace spic {
     class Scene {
         public:
             /**
-             * @brief This function is called by a Camera to render the scene on the engine.
-             * @spicapi
-             */
-            void RenderScene();
-
-            /**
              * @brief This property contains all the Game Object that are contained in this scene.
              * @spicapi
              */


### PR DESCRIPTION
RFC aangezien het niet de verantwoordelijkheid van de scene moet zijn om zichzelf te renderen.