### PR TITLE
Drop const from Point, it is a copy anyway

### DIFF
--- a/Input.hpp
+++ b/Input.hpp
@@ -285,7 +285,7 @@ namespace spic {
          * @brief The current mouse position in pixel coordinates. (Read Only)
          * @spicapi
          */
-        const Point MousePosition();
+        Point MousePosition();
 
         /**
          * @brief Returns the value of the virtual axis identified by axisName.


### PR DESCRIPTION
De const qualifier op deze functie heeft geen nut, aangezien er toch een kopie wordt gemaakt bij teruggave en het aanpassen van de waardes daarop geen invloed heeft op het object van andere receivers.

Sterker nog, niks staat je (bij g++) in de weg om zelf de const qualifier te droppen en het object alsnog aan te passen. De volgende code compiled:

```cpp
#include "Point.hpp"
#include <iostream>

const spic::Point getPoint() {
    spic::Point p;
    p.x = 11;
    return p;
}

int main () {
    spic::Point point = getPoint();

    std::cout << point.x << std::endl;
    point.x = 12;
    std::cout << point.x << std::endl;

    return 0;
}
```