### PR TITLE
Use bits for mouse buttons

### DIFF
--- a/Input.hpp
+++ b/Input.hpp
@@ -264,9 +264,9 @@ namespace spic {
          * @spicapi
          */
         enum class MouseButton {
-            LEFT = 1,
-            MIDDLE = 2,
-            RIGHT = 3
+            LEFT = 0b001, // 1
+            MIDDLE = 0b010, // 2
+            RIGHT = 0b100, // 4
         };
 
         /**


### PR DESCRIPTION
Suggestie vanuit onze groep om het muis input systeem te versimpelen.

Dit maakt het mogelijk om bitwise operations te doen op mouse button events, wat ook betekent dat er in één waarde meerdere muisknoppen tegelijkertijd gerepresenteerd kunnen worden (want bitmask).

Dit scheelt een hoop administratie over welke knoppen al ingedrukt waren vs zijn.

Als je met ints werkt zou je _in theorie_ deze waardes om kunnen zetten naar ints en dan de waardes 1, 2 en 4 moeten krijgen; het enige verschil is dan dat de rechtermuisknop 4 is ipv 3, en dat er meerdere knoppen ingedrukt kunnen zijn. Als je de enums goed gebruikt zou dit geen probleem moeten vormen, naast dat je misschien je equality operators even moet checken (`mouseButton == LEFT` gaat wss niet meer werken als er meerdere knoppen zijn, dan moet je `mouseButton & LEFT` doen)

We kunnen dit ook voor onszelf houden (en daarin iets afwijken van de gegeven API), maar RFC om te kijken wat Bob vindt.