### PR TITLE
Match GetAxis method with Unity Docs

### DIFF
--- a/Input.hpp
+++ b/Input.hpp
@@ -291,7 +291,7 @@ namespace spic {
          * @brief Returns the value of the virtual axis identified by axisName.
          * @spicapi
          */
-        double GetAxis();
+        double GetAxis(std::string axisName);
 
         /**
          * @brief Returns true while the user holds down the key identified by keycode.


### PR DESCRIPTION
Match GetAxis method with https://docs.unity3d.com/ScriptReference/Input.GetAxis.html
![image](https://user-images.githubusercontent.com/55792758/201685136-ce2c5ea3-d170-407f-85da-771ed2203794.png)
